### PR TITLE
Add -j2 when using the build_product script in CI

### DIFF
--- a/.github/workflows/automatus-cs8.yaml
+++ b/.github/workflows/automatus-cs8.yaml
@@ -54,7 +54,7 @@ jobs:
           prop_path: 'product'
       - name: Build product
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: ./build_product rhel8 --derivatives
+        run: ./build_product rhel8 --derivatives -j2
       - uses: actions/upload-artifact@v2
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:

--- a/.github/workflows/automatus-cs9.yaml
+++ b/.github/workflows/automatus-cs9.yaml
@@ -54,7 +54,7 @@ jobs:
           prop_path: 'product'
       - name: Build product
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: ./build_product rhel9 --derivatives
+        run: ./build_product rhel9 --derivatives -j2
       - uses: actions/upload-artifact@v2
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:

--- a/.github/workflows/automatus-sanity.yaml
+++ b/.github/workflows/automatus-sanity.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build product
-        run: ./build_product fedora --debug
+        run: ./build_product fedora --debug -j2
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ env.DATASTREAM }}

--- a/.github/workflows/automatus.yaml
+++ b/.github/workflows/automatus.yaml
@@ -52,7 +52,7 @@ jobs:
           prop_path: 'product'
       - name: Build product
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: ./build_product ${{steps.product.outputs.prop}} --datastream-only
+        run: ./build_product ${{steps.product.outputs.prop}} --datastream-only -j2
       - uses: actions/upload-artifact@v2
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:

--- a/.github/workflows/compare-ds.yaml
+++ b/.github/workflows/compare-ds.yaml
@@ -53,7 +53,7 @@ jobs:
           prop_path: 'product'
       - name: Build product ${{ github.base_ref }} (${{ steps.fork_point.outputs.FORK_POINT }})
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: ./build_product ${{steps.product.outputs.prop}} --datastream-only
+        run: ./build_product ${{steps.product.outputs.prop}} --datastream-only -j2
       - name: Copy built datastream stream to be compared
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: cp build/ssg-${{steps.product.outputs.prop}}-ds.xml ssg-${{steps.product.outputs.prop}}-ds.xml
@@ -65,7 +65,7 @@ jobs:
           clean: false
       - name: Build product
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: ./build_product ${{steps.product.outputs.prop}} --datastream-only
+        run: ./build_product ${{steps.product.outputs.prop}} --datastream-only -j2
       - name: Compare datastreams
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: utils/compare_ds.py ssg-${{steps.product.outputs.prop}}-ds.xml build/ssg-${{steps.product.outputs.prop}}-ds.xml | tee diff.log

--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -30,7 +30,8 @@ jobs:
               rhel8 \
               rhel9 \
               uos20 \
-              --derivatives
+              --derivatives \
+              -j2
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
@@ -46,7 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        run: ./build_product alinux2 alinux3 anolis23 anolis8 chromium fedora firefox rhcos4 rhel7 rhel8 rhel9 sle12 sle15 ubuntu2004 ubuntu2204 uos20
+        run: ./build_product alinux2 alinux3 anolis23 anolis8 chromium fedora firefox rhcos4 rhel7 rhel8 rhel9 sle12 sle15 ubuntu2004 ubuntu2204 uos20 -j2
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
@@ -69,7 +70,7 @@ jobs:
         env:
           ADDITIONAL_CMAKE_OPTIONS: "-DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED=ON"
         run: |-
-          ./build_product debian10 debian11
+          ./build_product debian10 debian11 -j2
       - name: Test
         working-directory: ./build
         run: ctest -j2 --output-on-failure -E unique-stigids
@@ -102,7 +103,8 @@ jobs:
               sle15 \
               ubuntu2004 \
               ubuntu2204 \
-              uos20
+              uos20 \
+              -j2
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
@@ -121,7 +123,8 @@ jobs:
         run: |-
           ./build_product \
               ubuntu2004 \
-              ubuntu2204
+              ubuntu2204 \
+              -j2
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
@@ -158,7 +161,8 @@ jobs:
               ubuntu2204 \
               uos20 \
               ocp4 \
-              eks
+              eks \
+              -j2
         env:
           ADDITIONAL_CMAKE_OPTIONS: "-DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED=ON"
       - name: Test
@@ -209,7 +213,8 @@ jobs:
                 ubuntu2004 \
                 ubuntu2204 \
                 uos20 \
-                ocp4
+                ocp4 \
+                -j2
       -   name: Test
           run: ctest -j2 --output-on-failure -E unique-stigids
           working-directory: ./build


### PR DESCRIPTION

#### Description:

We have two cores we might as well and use them in CI.


#### Rationale:

* Parallelism!
* Speed!
* Faster!
* More merging!
