### PR TITLE
Change platforms in some GRUB 2 rules

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
@@ -43,11 +43,7 @@ ocil: |-
     If properly configured, the output should indicate the following
     permissions: <tt>-rw-------</tt>
 
-{{% if 'ubuntu' in product %}}
 platform: not container
-{{% else %}}
-platform: not bootc
-{{% endif %}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_user_cfg/rule.yml
@@ -34,7 +34,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file=grub2_boot_path ~ "/user.cfg
 ocil: |-
     {{{ ocil_file_permissions(file=grub2_boot_path ~ "/user.cfg", perms="-rw-------") }}}
 
-platform: not bootc
+platform: not container
 
 template:
     name: file_permissions


### PR DESCRIPTION
#### Description:

Change platforms in some GRUB 2 rules

## Summary by Sourcery

Unify platform specifications in non-UEFI GRUB2 file permission rules to consistently use “not container” and remove obsolete conditional logic

Enhancements:
- Replace ‘not bootc’ with ‘not container’ in GRUB2 file permission rule templates
- Remove Ubuntu-specific conditional platform checks in non-UEFI file_permissions_grub2_cfg/rule.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected platform specifications to consistently exclude container environments, ensuring rules are properly applied outside of container setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->