### PR TITLE
Fix GRUB 2 UEFI selections in RHEL 9 ANSSI profiles

### DIFF
--- a/products/rhel9/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel9/profiles/anssi_bp28_enhanced.profile
@@ -51,13 +51,14 @@ selections:
     - '!package_kea_removed'
     - '!audit_rules_file_deletion_events_renameat2'
     - '!audit_rules_dac_modification_fchmodat2'
-    # RHEL9 unified the paths for grub2 files. These rules are selected in control file by R29.
+    # RHEL9 unified the paths for grub2 files. These rules are selected in control file by R5 and R29.
     - '!file_groupowner_efi_grub2_cfg'
     - '!file_owner_efi_grub2_cfg'
     - '!file_permissions_efi_grub2_cfg'
     - '!file_groupowner_efi_user_cfg'
     - '!file_owner_efi_user_cfg'
     - '!file_permissions_efi_user_cfg'
+    - '!grub2_uefi_password'
     # disable R45: Enable AppArmor security profiles
     - '!apparmor_configured'
     - '!all_apparmor_profiles_enforced'

--- a/products/rhel9/profiles/anssi_bp28_high.profile
+++ b/products/rhel9/profiles/anssi_bp28_high.profile
@@ -65,3 +65,11 @@ selections:
     - '!package_xinetd_removed'
     - '!package_ypbind_removed'
     - '!package_ypserv_removed'
+    # RHEL9 unified the paths for grub2 files. These rules are selected in control file by R5 and R29.
+    - '!file_groupowner_efi_grub2_cfg'
+    - '!file_owner_efi_grub2_cfg'
+    - '!file_permissions_efi_grub2_cfg'
+    - '!file_groupowner_efi_user_cfg'
+    - '!file_owner_efi_user_cfg'
+    - '!file_permissions_efi_user_cfg'
+    - '!grub2_uefi_password'

--- a/products/rhel9/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel9/profiles/anssi_bp28_intermediary.profile
@@ -47,3 +47,5 @@ selections:
   - '!package_xinetd_removed'
   - '!package_ypbind_removed'
   - '!package_ypserv_removed'
+  # RHEL9 unified the paths for grub2 files. These rules are selected in control file by R5.
+  - '!grub2_uefi_password'


### PR DESCRIPTION
GRUB 2 unified UEFI and non-UEFI configuration path to /boot/grub2. There are 2 groups of almost identical rules which differ only by configuration pathL
linux_os/guide/system/bootloader-grub2/uefi and
linux_os/guide/system/bootloader-grub2/non-uefi.
After the unification, only rules from the second group should be used.

The unselection of the rules from the other group was completed in past. However, we discovered one omission in RHEL 9 ANSSI profiles. Some rule were unselected in ANSSI enhanced profile, but they weren't unselected in ANSSI high profile. The ANSSI high profile is supposed to inherit from ANSSI enhanced profile. These rules come from R29 which is part of enhanced level.

Moreover, the rule grub2_uefi_password is also a logical duplicate of grub2_password and should be removed on RHEL 9.

## Summary by Sourcery

Bug Fixes:
- Unselect obsolete UEFI-specific GRUB2 rules in intermediary, enhanced, and high ANSSI RHEL9 profiles to align with the unified /boot/grub2 path and correct high profile inheritance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated profile descriptions to clarify which controls select grub2-related rules.
- **Refactor**
  - Adjusted profile rule selections to exclude specific grub2 UEFI configuration and password rules, reflecting unified grub2 file paths in RHEL9 and updated control coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->